### PR TITLE
fix: SecurityConfig가 빈으로 등록되지 않은 에러 -> @ComponentScan 에러 해결

### DIFF
--- a/user-service/src/main/java/com/meetravel/user_service/UserServiceApplication.java
+++ b/user-service/src/main/java/com/meetravel/user_service/UserServiceApplication.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.ComponentScan;
 
 @EnableDiscoveryClient
 @EnableFeignClients
-@ComponentScan(basePackages={"com.meetravel.module_common"})
+@ComponentScan(basePackages={"com.meetravel.module_common","com.meetravel.user_service"})
 @SpringBootApplication
 public class UserServiceApplication {
 


### PR DESCRIPTION
로그 확인해보니 제가 설정한 SecurityConfig에 등록된 필터들이 제대로 동작하지 않는 걸로보아 컴포넌트스캔이 제대로 안되는 문제였어서 해결했습니다~